### PR TITLE
Use built-in Foundation ISO8601 Date Formatter

### DIFF
--- a/ios/RCTFitness/RCTFitness+Utils.m
+++ b/ios/RCTFitness/RCTFitness+Utils.m
@@ -8,7 +8,6 @@
 
 #import <Foundation/Foundation.h>
 #import "RCTFitness+Utils.h"
-#include <time.h>
 
 @implementation RCTFitness(Utils)
 

--- a/ios/RCTFitness/RCTFitness+Utils.m
+++ b/ios/RCTFitness/RCTFitness+Utils.m
@@ -15,6 +15,7 @@
 + (NSString *)ISO8601StringFromDate: (NSDate*) date {
     // Cache the formatter in thread local storage the first
     // time it's created and then re-use it every other time.
+    NSString *cachedISO8601DateFormatterKey = @"cachedNSISO8601DateFormatterKey";
     NSMutableDictionary *threadDictionary = [[NSThread currentThread] threadDictionary];
     NSISO8601DateFormatter *dateFormatter = threadDictionary[cachedISO8601DateFormatterKey];
     

--- a/ios/RCTFitness/RCTFitness+Utils.m
+++ b/ios/RCTFitness/RCTFitness+Utils.m
@@ -6,22 +6,26 @@
 //  Copyright © 2018 Facebook. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "RCTFitness+Utils.h"
 #include <time.h>
 
 @implementation RCTFitness(Utils)
-
+    
 + (NSString *)ISO8601StringFromDate: (NSDate*) date {
-    struct tm *timeinfo;
-    char buffer[80];
+    // Cache the formatter in thread local storage the first
+    // time it's created and then re-use it every other time.
+    NSMutableDictionary *threadDictionary = [[NSThread currentThread] threadDictionary];
+    NSISO8601DateFormatter *dateFormatter = threadDictionary[cachedISO8601DateFormatterKey];
     
-    time_t rawtime = [date timeIntervalSince1970] - [[NSTimeZone localTimeZone] secondsFromGMT];
-    timeinfo = localtime(&rawtime);
+    if (!dateFormatter) {
+        dateFormatter = [[NSISO8601DateFormatter alloc] init];
+        threadDictionary[cachedISO8601DateFormatterKey] = dateFormatter;
+    }
     
-    strftime(buffer, 80, "%Y-%m-%dT%H:%M:%S%z", timeinfo);
-    
-    return [NSString stringWithCString:buffer encoding:NSUTF8StringEncoding];
+    return [dateFormatter stringFromDate:date];
 }
+
 
 + (NSDate *)dateFromTimeStamp:(NSTimeInterval) timestamp {
     if (!timestamp) {

--- a/ios/RCTFitness/RCTFitness+Utils.m
+++ b/ios/RCTFitness/RCTFitness+Utils.m
@@ -11,27 +11,25 @@
 #include <time.h>
 
 @implementation RCTFitness(Utils)
-    
-+ (NSString *)ISO8601StringFromDate: (NSDate*) date {
-    // Cache the formatter in thread local storage the first
-    // time it's created and then re-use it every other time.
-    NSString *cachedISO8601DateFormatterKey = @"cachedNSISO8601DateFormatterKey";
-    NSMutableDictionary *threadDictionary = [[NSThread currentThread] threadDictionary];
-    NSISO8601DateFormatter *dateFormatter = threadDictionary[cachedISO8601DateFormatterKey];
-    
-    if (!dateFormatter) {
+
++ (NSISO8601DateFormatter *)dateFormatter {
+    static dispatch_once_t once;
+    static NSISO8601DateFormatter *dateFormatter;
+    dispatch_once(&once, ^{
         dateFormatter = [[NSISO8601DateFormatter alloc] init];
-        threadDictionary[cachedISO8601DateFormatterKey] = dateFormatter;
-    }
-    
-    return [dateFormatter stringFromDate:date];
+    });
+    return dateFormatter;
 }
 
++ (NSString *)ISO8601StringFromDate:(NSDate *)date {
+    return [[self dateFormatter] stringFromDate:date];
+}
 
-+ (NSDate *)dateFromTimeStamp:(NSTimeInterval) timestamp {
++ (NSDate *)dateFromTimeStamp:(NSTimeInterval)timestamp {
     if (!timestamp) {
         return [NSDate date];
     }
+    
     return [NSDate dateWithTimeIntervalSince1970:timestamp];
 }
 


### PR DESCRIPTION
What the title says -- instead of writing your own format function to manually turn a date into an ISO8601-compliant string, we can just use the built-in date formatter's `stringFromDate` function which is much less prone to bugs and mistakes, and we don't have to maintain the implementation ourselves.