### PR TITLE
Subscribe to Google Fit Activity

### DIFF
--- a/android/src/main/java/com/ovalmoney/fitness/RNFitnessModule.java
+++ b/android/src/main/java/com/ovalmoney/fitness/RNFitnessModule.java
@@ -49,6 +49,15 @@ public class RNFitnessModule extends ReactContextBaseJavaModule{
       promise.reject(new Throwable());
     }
   }
+  
+    @ReactMethod
+  public void subscribe(Promise promise){
+    try {
+      manager.subscribe(getCurrentActivity(), promise);
+    }catch(Error e){
+      promise.reject(e);
+    }
+  }
 
   @ReactMethod
   public void getSteps(double startDate, double endDate, Promise promise){

--- a/android/src/main/java/com/ovalmoney/fitness/RNFitnessModule.java
+++ b/android/src/main/java/com/ovalmoney/fitness/RNFitnessModule.java
@@ -51,13 +51,22 @@ public class RNFitnessModule extends ReactContextBaseJavaModule{
   }
   
     @ReactMethod
-  public void subscribe(Promise promise){
+  public void subscribeToActivity(Promise promise){
     try {
-      manager.subscribe(getCurrentActivity(), promise);
+      manager.subscribeToActivity(getCurrentActivity(), promise);
     }catch(Error e){
       promise.reject(e);
     }
   }
+
+      @ReactMethod
+    public void subscribeToSteps(Promise promise){
+      try {
+        manager.subscribeToSteps(getCurrentActivity(), promise);
+      }catch(Error e){
+        promise.reject(e);
+      }
+    }
 
   @ReactMethod
   public void getSteps(double startDate, double endDate, Promise promise){

--- a/android/src/main/java/com/ovalmoney/fitness/manager/Manager.java
+++ b/android/src/main/java/com/ovalmoney/fitness/manager/Manager.java
@@ -91,6 +91,25 @@ public class Manager implements ActivityEventListener {
 
     @Override
     public void onNewIntent(Intent intent) { }
+    
+    public void subscribe(Context context, final Promise promise){
+
+      Fitness.getRecordingClient(context, GoogleSignIn.getLastSignedInAccount(context))
+              .subscribe(DataType.TYPE_ACTIVITY_SAMPLES)
+              .addOnSuccessListener(new OnSuccessListener<Void>() {
+                  @Override
+                  public void onSuccess(Void aVoid) {
+                      promise.resolve(true);
+                  }
+              })
+              .addOnFailureListener(new OnFailureListener() {
+                  @Override
+                  public void onFailure(@NonNull Exception e) {
+                     promise.resolve(false);
+                  }
+              });
+
+            }
 
     public void getSteps(Context context, double startDate, double endDate, final Promise promise){
         DataSource ESTIMATED_STEP_DELTAS = new DataSource.Builder()

--- a/android/src/main/java/com/ovalmoney/fitness/manager/Manager.java
+++ b/android/src/main/java/com/ovalmoney/fitness/manager/Manager.java
@@ -27,6 +27,7 @@ import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
+import com.google.android.gms.fitness.data.Subscription;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -58,8 +59,10 @@ public class Manager implements ActivityEventListener {
     public boolean isAuthorized(final Activity activity){
         if(isGooglePlayServicesAvailable(activity)) {
             FitnessOptions fitnessOptions = FitnessOptions.builder()
-                    .addDataType(DataType.TYPE_STEP_COUNT_DELTA, FitnessOptions.ACCESS_READ)
+                    .addDataType(DataType.TYPE_STEP_COUNT_DELTA, FitnessOptions.ACCESS_WRITE)
                     .addDataType(DataType.TYPE_DISTANCE_DELTA, FitnessOptions.ACCESS_READ)
+                    .addDataType(DataType.TYPE_ACTIVITY_SAMPLES, FitnessOptions.ACCESS_WRITE)
+                    .addDataType(DataType.TYPE_STEP_COUNT_CUMULATIVE, FitnessOptions.ACCESS_WRITE)
                     .build();
             return GoogleSignIn.hasPermissions(GoogleSignIn.getLastSignedInAccount(activity), fitnessOptions);
         }
@@ -69,8 +72,10 @@ public class Manager implements ActivityEventListener {
     public void requestPermissions(@NonNull Activity currentActivity, Promise promise) {
         this.promise = promise;
         FitnessOptions fitnessOptions = FitnessOptions.builder()
-                .addDataType(DataType.TYPE_STEP_COUNT_DELTA, FitnessOptions.ACCESS_READ)
+                .addDataType(DataType.TYPE_STEP_COUNT_DELTA, FitnessOptions.ACCESS_WRITE)
                 .addDataType(DataType.TYPE_DISTANCE_DELTA, FitnessOptions.ACCESS_READ)
+                .addDataType(DataType.TYPE_ACTIVITY_SAMPLES, FitnessOptions.ACCESS_WRITE)
+                .addDataType(DataType.TYPE_STEP_COUNT_CUMULATIVE, FitnessOptions.ACCESS_WRITE)
                 .build();
         GoogleSignIn.requestPermissions(
                 currentActivity,
@@ -92,7 +97,7 @@ public class Manager implements ActivityEventListener {
     @Override
     public void onNewIntent(Intent intent) { }
     
-    public void subscribe(Context context, final Promise promise){
+    public void subscribeToActivity(Context context, final Promise promise){
 
       Fitness.getRecordingClient(context, GoogleSignIn.getLastSignedInAccount(context))
               .subscribe(DataType.TYPE_ACTIVITY_SAMPLES)
@@ -110,6 +115,27 @@ public class Manager implements ActivityEventListener {
               });
 
             }
+
+        public void subscribeToSteps(Context context, final Promise promise){
+
+
+
+          Fitness.getRecordingClient(context, GoogleSignIn.getLastSignedInAccount(context))
+                  .subscribe(DataType.TYPE_STEP_COUNT_DELTA)
+                  .addOnSuccessListener(new OnSuccessListener<Void>() {
+                      @Override
+                      public void onSuccess(Void aVoid) {
+                          promise.resolve(true);
+                      }
+                  })
+                  .addOnFailureListener(new OnFailureListener() {
+                      @Override
+                      public void onFailure(@NonNull Exception e) {
+                         promise.resolve(false);
+                      }
+                  });
+
+                }
 
     public void getSteps(Context context, double startDate, double endDate, final Promise promise){
         DataSource ESTIMATED_STEP_DELTAS = new DataSource.Builder()


### PR DESCRIPTION
I noticed that I must have Google Fit on my device to record activity.

I wanted to have the module record activity even if the device does not have Google Fit installed, so I added a subscribe function that writes user activity to the Google Fit Store.

It should be initialized when loading the app via Fitness.subscribe(), it returns a promise to show the status of the subscription (true for success and false for failure).