### PR TITLE
Fix a small typo in js/index.d.ts "Wrtie"

### DIFF
--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -9,7 +9,7 @@ export declare enum PermissionKind {
 
 export declare enum PermissionAccess {
   Read = 0,
-  Wrtie = 1,
+  Write = 1,
 }
 
 export declare type Permission = {


### PR DESCRIPTION
There is a small typo in js/index.d.ts when declaring the PermissionAccess enum in line 12. It is supposed to say "Write", but currently says "Wrtie". This has a negative effect on code suggestions, where some IDE's (tested on VS Code) will suggest "Wrtie" although it will always result in an error. 